### PR TITLE
🐛Fix: SectionWrapper parseElement 함수 오타 수정

### DIFF
--- a/src/main/java/com/likelion/backendplus4/yakplus/scraper/drug/detail/XMLParsing.java
+++ b/src/main/java/com/likelion/backendplus4/yakplus/scraper/drug/detail/XMLParsing.java
@@ -55,7 +55,7 @@ public class XMLParsing {
 
 		@Override
 		public SectionWrapper parseElement(Element element) {
-			this.section = section;
+			this.section = element;
 			sectionJson = mapper.createObjectNode();
 			toJsonNodeFromElement(sectionJson, section);
 			return this;


### PR DESCRIPTION
### this.section = section ->this.section = element로 수정
section 내부 객체 파싱되지 않던 문제 수정했습니다.